### PR TITLE
Add exposing-applications examples

### DIFF
--- a/kubernetes/exposing-applications/README.md
+++ b/kubernetes/exposing-applications/README.md
@@ -1,0 +1,3 @@
+# Exposing Applications
+
+These are supporting YAML example files for CoreWeave's Exposing Applications documentation.

--- a/kubernetes/exposing-applications/external-dns.yaml
+++ b/kubernetes/exposing-applications/external-dns.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/address-pool: public-ord1
+    external-dns.alpha.kubernetes.io/hostname: my-sshd.tenant-test-default.coreweave.cloud
+  name: sshd
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: sshd
+      port: 22
+      protocol: TCP
+      targetPort: sshd
+  selector:
+    app.kubernetes.io/name: sshd

--- a/kubernetes/exposing-applications/ingress-example.yaml
+++ b/kubernetes/exposing-applications/ingress-example.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: tenant-test-default-redirect-secure@kubernetescrd
+  labels:
+    app.kubernetes.io/name: my-app
+  name: my-app
+spec:
+  rules:
+  - host: my-app.tenant-test-default.ord1.ingress.coreweave.cloud
+    http: 
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: my-app
+              port:
+                number: 80
+  tls:
+  - hosts:
+    - my-app.tenant-test-default.ord1.ingress.coreweave.cloud
+    secretName: my-app-tls # This secret is automatically created for you
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-secure
+  namespace: tenant-test-default
+spec:
+  redirectScheme:
+    permanent: true
+    scheme: https

--- a/kubernetes/exposing-applications/ip-direct-attached-to-pod.yaml
+++ b/kubernetes/exposing-applications/ip-direct-attached-to-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+  annotations:
+    metallb.universe.tf/address-pool: public-ord1
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  ports:
+    - port: 1 # Do not change this
+      targetPort: attach
+      protocol: TCP
+      name: attach
+     # Do not add any additional ports, it is not required for direct attach
+  selector: 
+    coreweave.cloud/ignore: ignore # Do not change this

--- a/kubernetes/exposing-applications/sshd-public-service.yaml
+++ b/kubernetes/exposing-applications/sshd-public-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/address-pool: public-ord1
+    metallb.universe.tf/allow-shared-ip: default
+  name: sshd
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: sshd
+      port: 22
+      protocol: TCP
+      targetPort: sshd
+  selector:
+    app.kubernetes.io/name: sshd


### PR DESCRIPTION
Add YAML examples for the [Exposing Applications documentation](https://docs.coreweave.com/coreweave-kubernetes/exposing-applications).