### PR TITLE
fix: Fix Open WebUI auth loop and pin image to stable tag

### DIFF
--- a/cks/llm-on-cks.yaml
+++ b/cks/llm-on-cks.yaml
@@ -77,22 +77,20 @@ spec:
     spec:
       containers:
         - name: open-webui
-          image: ghcr.io/open-webui/open-webui:main
+          image: ghcr.io/open-webui/open-webui:v0.6.5
           ports:
             - containerPort: 8080
           env:
             - name: WEBUI_AUTH
               value: "false"
+            - name: ENABLE_SIGNUP
+              value: "true"
+            - name: ENABLE_LOGIN_FORM
+              value: "true"
             - name: OPENAI_API_BASE_URL
               value: "http://llama-3-1-8b-svc:11434/v1"
-            - name: PROVIDER
-              value: "vllm"
-            - name: MODEL_NAME
-              value: "meta-llama/Llama-3.1-8B-Instruct"
-            - name: MODEL_ENDPOINT
-              value: "http://llama-3-1-8b-svc:11434/v1/completions"
-            - name: ENABLE_TOOLs
-              value: "false"
+            - name: OPENAI_API_KEY
+              value: "not-needed"
           volumeMounts:
             - name: open-webui-storage
               mountPath: /app/backend/data


### PR DESCRIPTION
## Summary

- Pins the Open WebUI image from `:main` to `v0.6.5` — using `:main` caused silent breaking changes when the upstream image was rebuilt, which is what triggered the auth loop
- Adds `ENABLE_SIGNUP: "true"` and `ENABLE_LOGIN_FORM: "true"` so `WEBUI_AUTH=false` reliably bypasses the sign-in screen in newer Open WebUI versions (without these, newer builds return `POST /signin 400` and loop indefinitely)
- Adds `OPENAI_API_KEY: "not-needed"` — required by Open WebUI when using the OpenAI-compatible API, even though vLLM doesn't enforce key auth; without it the connection can silently fail
- Removes unrecognized env vars (`PROVIDER`, `MODEL_NAME`, `MODEL_ENDPOINT`, `ENABLE_TOOLs`) that had no effect and added noise

## Context

Identified in the friction log for https://docs.coreweave.com/products/cks/deploy-model. After completing the tutorial, the Open WebUI hung indefinitely at sign-in. Root cause: the `:main` image tag is a moving target and recent Open WebUI versions changed auth behavior.

## Test plan

- [x] Apply manifest to a CKS cluster with a GPU node pool
- [x] Confirm vLLM pod reaches `Running` and logs show `Application startup complete.`
- [x] `kubectl port-forward svc/open-webui-svc 8080:80` and open http://localhost:8080
- [x] Confirm Open WebUI loads directly (no sign-in screen, no loop)
- [x] Send a prompt to the model and confirm a response

🤖 Generated with [Claude Code](https://claude.com/claude-code)