### PR TITLE
docs: Add delete cold objects storage example

### DIFF
--- a/storage/delete-cold-objects/README.md
+++ b/storage/delete-cold-objects/README.md
@@ -1,0 +1,53 @@
+# Delete cold objects
+
+Supporting script for [Delete cold objects](https://docs.coreweave.com/products/storage/object-storage/using-object-storage/delete-cold-objects)
+on docs.coreweave.com.
+
+`delete_cold_objects.py` is a single-file, staged workflow for safely identifying
+and deleting cold objects in CoreWeave AI Object Storage when the source of truth
+for the data lives elsewhere. It uses Inventory Reporting, a quarantine buffer
+window, and versioning as layers of defense against deleting recently accessed
+objects.
+
+## Stages
+
+| Subcommand   | Stage   | What it does                                                        |
+| ------------ | ------- | ------------------------------------------------------------------ |
+| `identify`   | Stage 1 | Read an inventory report and list cold candidates.                 |
+| `quarantine` | Stage 2 | Tag candidates and persist state for the buffer window.            |
+| `delete`     | Stage 3 | Re-check access times, enable versioning, delete confirmed keys.   |
+| `recover`    | Stage 4 | Restore mistakenly deleted keys before cleanup runs.               |
+| `cleanup`    | Stage 4 | Permanently remove recovery copies and delete markers.            |
+
+## Configuration
+
+Set these environment variables before running:
+
+```bash
+export ACCESS_KEY_ID="[ACCESS-KEY-ID]"
+export SECRET_ACCESS_KEY="[SECRET-ACCESS-KEY]"
+export BUCKET="[BUCKET-NAME]"
+# Optional, with defaults shown:
+export ENDPOINT_URL="https://cwobject.com"   # LOTA: http://cwlota.com
+export REGION="US-EAST-04A"
+```
+
+## Usage
+
+```bash
+python delete_cold_objects.py identify --inventory inventory.csv --threshold-days 90
+python delete_cold_objects.py quarantine
+# ...wait the buffer window (for example, 30 days)...
+python delete_cold_objects.py delete --inventory inventory_fresh.csv
+# ...wait the recovery window (for example, 30 days)...
+python delete_cold_objects.py cleanup
+```
+
+The inventory CSV is headerless. Confirm the column order against your report's
+`manifest.json` (`fileSchema`) and pass `--fields` if it differs from the
+documented default.
+
+## Requirements
+
+- Python 3.9 or later
+- `boto3`

--- a/storage/delete-cold-objects/delete_cold_objects.py
+++ b/storage/delete-cold-objects/delete_cold_objects.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Delete cold objects from CoreWeave AI Object Storage.
+
+A safe, staged workflow for identifying and deleting cold objects when the
+source of truth for the data lives elsewhere. See the companion guide:
+https://docs.coreweave.com/products/storage/object-storage/using-object-storage/delete-cold-objects
+
+The workflow runs in four stages, each a subcommand:
+
+  identify   Stage 1  Read an inventory report and list cold candidates.
+  quarantine Stage 2  Tag candidates and persist state for the buffer window.
+  delete     Stage 3  Re-check access times, enable versioning, delete cold keys.
+  cleanup    Stage 4  Permanently remove recovery copies and delete markers.
+
+Plus a recovery helper for undoing mistakes before cleanup runs:
+
+  recover    Stage 4  Restore mistakenly deleted keys by removing delete markers.
+
+Stages 1 and 2 typically run together; stages 3 and 4 run later, in separate
+processes, after the buffer and recovery windows elapse. State is passed
+between stages through two local JSON files.
+
+Configuration comes from environment variables:
+
+  export ACCESS_KEY_ID="[ACCESS-KEY-ID]"
+  export SECRET_ACCESS_KEY="[SECRET-ACCESS-KEY]"
+  export BUCKET="[BUCKET-NAME]"
+  # Optional, with defaults shown:
+  export ENDPOINT_URL="https://cwobject.com"   # LOTA: http://cwlota.com
+  export REGION="US-EAST-04A"
+
+Example:
+
+  python delete_cold_objects.py identify --inventory inventory.csv --threshold-days 90
+  python delete_cold_objects.py quarantine
+  # ...wait the buffer window (for example, 30 days)...
+  python delete_cold_objects.py delete --inventory inventory_fresh.csv
+  # ...wait the recovery window (for example, 30 days)...
+  python delete_cold_objects.py cleanup
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from botocore.client import Config
+
+# Column order is set by your inventory configuration and listed in the
+# report's manifest.json (fileSchema). This default matches the schema shown in
+# the CoreWeave Inventory Reporting docs. Verify it against your own
+# manifest.json before relying on the output; a mismatch silently misaligns
+# every column because the CSV is headerless.
+DEFAULT_FIELDS = [
+    "Bucket", "Key", "VersionId", "IsLatest", "IsDeleteMarker",
+    "Size", "StorageClass", "LastAccessedDate",
+]
+
+QUARANTINE_TAG_KEY = "quarantine_set"
+STATE_FILE = "quarantine_state.json"
+CONFIRMED_FILE = "confirmed_candidates.json"
+
+
+# --------------------------------------------------------------------------- #
+# Client and helpers
+# --------------------------------------------------------------------------- #
+def make_client():
+    """Build an S3 client for AI Object Storage from environment variables."""
+    boto_config = Config(
+        region_name=os.environ.get("REGION", "US-EAST-04A"),
+        s3={"addressing_style": "virtual"},
+    )
+    return boto3.client(
+        "s3",
+        endpoint_url=os.environ.get("ENDPOINT_URL", "https://cwobject.com"),
+        aws_access_key_id=os.environ["ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["SECRET_ACCESS_KEY"],
+        config=boto_config,
+    )
+
+
+def require_bucket():
+    bucket = os.environ.get("BUCKET")
+    if not bucket:
+        sys.exit("Set the BUCKET environment variable to the source bucket name.")
+    return bucket
+
+
+def parse_last_access(value):
+    """Parse an RFC 3339 timestamp. The 'Z' -> '+00:00' swap keeps this working
+    on Python versions before 3.11."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def read_candidates(inventory_path, fields, keep=None):
+    """Yield keys of current live objects that have a LastAccessedDate.
+
+    keep, if given, is a predicate on the parsed last-access datetime.
+    """
+    with open(inventory_path) as f:
+        # Inventory CSVs are headerless; provide column names explicitly.
+        reader = csv.DictReader(f, fieldnames=fields)
+        for row in reader:
+            # Only consider current live objects.
+            if row["IsLatest"] != "true" or row["IsDeleteMarker"] == "true":
+                continue
+            if not row["LastAccessedDate"]:
+                continue
+            last_access = parse_last_access(row["LastAccessedDate"])
+            if keep is None or keep(last_access):
+                yield row["Key"], last_access
+
+
+# --------------------------------------------------------------------------- #
+# Stage 1: Identify
+# --------------------------------------------------------------------------- #
+def cmd_identify(args):
+    fields = args.fields.split(",") if args.fields else DEFAULT_FIELDS
+    cutoff = datetime.now(timezone.utc) - timedelta(days=args.threshold_days)
+
+    candidates = [
+        key for key, _ in read_candidates(
+            args.inventory, fields, keep=lambda last: last < cutoff
+        )
+    ]
+    with open(STATE_FILE, "w") as f:
+        json.dump({"quarantine_date": None, "candidates": candidates}, f)
+    print(f"Identified {len(candidates)} cold candidate(s); wrote {STATE_FILE}.")
+
+
+# --------------------------------------------------------------------------- #
+# Stage 2: Quarantine
+# --------------------------------------------------------------------------- #
+def cmd_quarantine(args):
+    s3 = make_client()
+    bucket = require_bucket()
+
+    with open(STATE_FILE) as f:
+        state = json.load(f)
+    candidates = state["candidates"]
+
+    quarantine_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    quarantine_tag = {"Key": QUARANTINE_TAG_KEY, "Value": quarantine_date}
+
+    for key in candidates:
+        # Fetch existing tags so you don't overwrite them.
+        response = s3.get_object_tagging(Bucket=bucket, Key=key)
+        existing_tags = response.get("TagSet", [])
+        # Drop any prior quarantine_set tag, then append the current one so the
+        # workflow is safe to re-run.
+        merged_tags = [t for t in existing_tags if t["Key"] != QUARANTINE_TAG_KEY]
+        merged_tags.append(quarantine_tag)
+        s3.put_object_tagging(Bucket=bucket, Key=key, Tagging={"TagSet": merged_tags})
+
+    state["quarantine_date"] = quarantine_date
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f)
+    print(f"Quarantined {len(candidates)} object(s) with {QUARANTINE_TAG_KEY}="
+          f"{quarantine_date}; updated {STATE_FILE}.")
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3: Delete
+# --------------------------------------------------------------------------- #
+def cmd_delete(args):
+    s3 = make_client()
+    bucket = require_bucket()
+    fields = args.fields.split(",") if args.fields else DEFAULT_FIELDS
+
+    with open(STATE_FILE) as f:
+        state = json.load(f)
+    quarantine_date = state["quarantine_date"]
+    candidates = state["candidates"]
+    if not quarantine_date:
+        sys.exit("State has no quarantine_date; run the quarantine stage first.")
+
+    quarantine_start = datetime.strptime(quarantine_date, "%Y-%m-%d").replace(
+        tzinfo=timezone.utc
+    )
+    quarantined_keys = set(candidates)
+
+    # Re-check a fresh inventory generated AFTER the buffer window closed. Keys
+    # accessed during the window have a newer LastAccessedDate and are spared.
+    confirmed_candidates = [
+        key for key, last in read_candidates(
+            args.inventory, fields, keep=lambda last: last < quarantine_start
+        )
+        if key in quarantined_keys
+    ]
+
+    # Ensure versioning is on so each delete is recoverable. Idempotent.
+    s3.put_bucket_versioning(
+        Bucket=bucket, VersioningConfiguration={"Status": "Enabled"}
+    )
+
+    # delete_objects accepts up to 1000 keys per call and returns HTTP 200 even
+    # when individual keys fail, so inspect the Errors list in each response.
+    errors = []
+    for i in range(0, len(confirmed_candidates), 1000):
+        batch = [{"Key": k} for k in confirmed_candidates[i:i + 1000]]
+        resp = s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+        errors.extend(resp.get("Errors", []))
+
+    with open(CONFIRMED_FILE, "w") as f:
+        json.dump(confirmed_candidates, f)
+
+    print(f"Deleted {len(confirmed_candidates)} confirmed cold key(s); "
+          f"wrote {CONFIRMED_FILE}.")
+    if errors:
+        print(f"{len(errors)} delete(s) failed; first error: {errors[0]}")
+
+
+# --------------------------------------------------------------------------- #
+# Stage 4: Recover (optional, before cleanup)
+# --------------------------------------------------------------------------- #
+def cmd_recover(args):
+    s3 = make_client()
+    bucket = require_bucket()
+    keys_to_recover = set(args.keys)
+
+    # Remove the current delete marker for each key, promoting its recovery copy
+    # back to current. Recover the whole set in one pass, then filter the state
+    # file once, so concurrent single-key runs can't clobber each other.
+    paginator = s3.get_paginator("list_object_versions")
+    markers_to_remove = []
+    for page in paginator.paginate(Bucket=bucket):
+        for marker in page.get("DeleteMarkers", []):
+            if marker["Key"] in keys_to_recover and marker["IsLatest"]:
+                markers_to_remove.append(
+                    {"Key": marker["Key"], "VersionId": marker["VersionId"]}
+                )
+
+    errors = []
+    for i in range(0, len(markers_to_remove), 1000):
+        resp = s3.delete_objects(
+            Bucket=bucket, Delete={"Objects": markers_to_remove[i:i + 1000]}
+        )
+        errors.extend(resp.get("Errors", []))
+
+    failed_keys = {e["Key"] for e in errors}
+    recovered = keys_to_recover - failed_keys
+
+    # Drop only successfully recovered keys from the cleanup list so a key whose
+    # marker removal failed stays in the list and is retried or cleaned up.
+    try:
+        with open(CONFIRMED_FILE) as f:
+            confirmed = json.load(f)
+        confirmed = [k for k in confirmed if k not in recovered]
+        with open(CONFIRMED_FILE, "w") as f:
+            json.dump(confirmed, f)
+    except FileNotFoundError:
+        pass
+
+    print(f"Recovered {len(recovered)} key(s).")
+    if failed_keys:
+        print(f"{len(failed_keys)} key(s) could not be recovered; "
+              f"first error: {errors[0]}")
+
+
+# --------------------------------------------------------------------------- #
+# Stage 4: Cleanup
+# --------------------------------------------------------------------------- #
+def cmd_cleanup(args):
+    s3 = make_client()
+    bucket = require_bucket()
+
+    with open(CONFIRMED_FILE) as f:
+        confirmed_candidates = set(json.load(f))
+
+    paginator = s3.get_paginator("list_object_versions")
+    versions_by_key = defaultdict(list)
+    current_is_delete_marker = {}
+
+    # A full-bucket listing is simplest. If confirmed_candidates is small
+    # relative to the bucket, list per key with Prefix=key instead.
+    for page in paginator.paginate(Bucket=bucket):
+        for v in page.get("Versions", []):
+            if v["Key"] in confirmed_candidates:
+                versions_by_key[v["Key"]].append(
+                    {"Key": v["Key"], "VersionId": v["VersionId"]}
+                )
+                if v["IsLatest"]:
+                    current_is_delete_marker[v["Key"]] = False
+        for m in page.get("DeleteMarkers", []):
+            if m["Key"] in confirmed_candidates:
+                versions_by_key[m["Key"]].append(
+                    {"Key": m["Key"], "VersionId": m["VersionId"]}
+                )
+                if m["IsLatest"]:
+                    current_is_delete_marker[m["Key"]] = True
+
+    # Purge only keys whose current version is still a delete marker. A key that
+    # was restored or re-created since Stage 3 has a live current version and is
+    # left untouched.
+    to_delete = []
+    skipped = []
+    for key in confirmed_candidates:
+        if current_is_delete_marker.get(key) is True:
+            to_delete.extend(versions_by_key[key])
+        else:
+            skipped.append(key)
+
+    errors = []
+    for i in range(0, len(to_delete), 1000):
+        resp = s3.delete_objects(
+            Bucket=bucket, Delete={"Objects": to_delete[i:i + 1000]}
+        )
+        errors.extend(resp.get("Errors", []))
+
+    print(f"Purged versions for {len(confirmed_candidates) - len(skipped)} key(s).")
+    if errors:
+        print(f"{len(errors)} version(s) failed to delete; first error: {errors[0]}")
+    if skipped:
+        print(f"Skipped {len(skipped)} key(s) no longer in a deleted state.")
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Safely identify and delete cold objects in CoreWeave AI "
+                    "Object Storage.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_identify = sub.add_parser("identify", help="Stage 1: list cold candidates.")
+    p_identify.add_argument("--inventory", default="inventory.csv",
+                            help="Local inventory CSV path (default: inventory.csv).")
+    p_identify.add_argument("--threshold-days", type=int, default=90,
+                            help="Cold threshold in days (default: 90).")
+    p_identify.add_argument("--fields", default="",
+                            help="Comma-separated inventory column names. "
+                                 "Defaults to the documented CoreWeave schema.")
+    p_identify.set_defaults(func=cmd_identify)
+
+    p_quar = sub.add_parser("quarantine", help="Stage 2: tag candidates, save state.")
+    p_quar.set_defaults(func=cmd_quarantine)
+
+    p_del = sub.add_parser("delete", help="Stage 3: re-check, version, delete.")
+    p_del.add_argument("--inventory", default="inventory_fresh.csv",
+                       help="Fresh inventory CSV generated after the buffer "
+                            "window (default: inventory_fresh.csv).")
+    p_del.add_argument("--fields", default="",
+                       help="Comma-separated inventory column names.")
+    p_del.set_defaults(func=cmd_delete)
+
+    p_rec = sub.add_parser("recover", help="Stage 4: restore mistakenly deleted keys.")
+    p_rec.add_argument("keys", nargs="+", help="Object keys to restore.")
+    p_rec.set_defaults(func=cmd_recover)
+
+    p_clean = sub.add_parser("cleanup", help="Stage 4: permanently remove copies.")
+    p_clean.set_defaults(func=cmd_cleanup)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/storage/delete-cold-objects/test_delete_cold_objects.py
+++ b/storage/delete-cold-objects/test_delete_cold_objects.py
@@ -1,0 +1,144 @@
+"""End-to-end test of delete_cold_objects.py against a mock S3 (moto).
+
+Drives the assembled script through identify -> quarantine -> delete -> recover
+-> cleanup exactly as a user would, using the documented CoreWeave 8-column
+inventory schema.
+"""
+import csv
+import json
+import os
+import boto3
+from botocore.client import Config
+from datetime import datetime, timedelta, timezone
+from moto import mock_aws
+
+import delete_cold_objects as dco
+
+os.environ["ACCESS_KEY_ID"] = os.environ["AWS_ACCESS_KEY_ID"] = "testkey"
+os.environ["SECRET_ACCESS_KEY"] = os.environ["AWS_SECRET_ACCESS_KEY"] = "testsecret"
+os.environ["BUCKET"] = "cold-test"
+os.environ["REGION"] = "us-east-1"          # region moto accepts
+os.environ.pop("ENDPOINT_URL", None)         # let moto intercept default calls
+
+WORK = os.path.dirname(os.path.abspath(__file__))
+os.chdir(WORK)
+BUCKET = os.environ["BUCKET"]
+FIELDS = dco.DEFAULT_FIELDS  # documented 8-column schema
+
+results = []
+def check(name, cond, detail=""):
+    results.append((name, cond, detail))
+    print(f"[{'PASS' if cond else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+
+
+def row(key, last_access, is_latest="true", is_dm="false", vid="v1"):
+    return {"Bucket": BUCKET, "Key": key, "VersionId": vid, "IsLatest": is_latest,
+            "IsDeleteMarker": is_dm, "Size": "10", "StorageClass": "STANDARD",
+            "LastAccessedDate": last_access}
+
+
+def write_inv(path, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        for r in rows:
+            w.writerow([r.get(k, "") for k in FIELDS])
+
+
+# Point the script's client at moto by overriding endpoint via env each call.
+def patched_make_client():
+    cfg = Config(region_name="us-east-1", s3={"addressing_style": "virtual"})
+    return boto3.client("s3", aws_access_key_id="testkey",
+                        aws_secret_access_key="testsecret", config=cfg)
+
+
+@mock_aws
+def run():
+    dco.make_client = patched_make_client  # bypass custom endpoint for the mock
+    now = datetime.now(timezone.utc)
+    old = (now - timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    recent = (now - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    accessed_during = (now - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    write_inv("inventory.csv", [
+        row("cold/1", old), row("cold/2", old), row("cold/3", old),
+        row("warm/1", old), row("hot/1", recent), row("noacc", ""),
+        row("nc", old, is_latest="false"), row("dm", old, is_dm="true"),
+    ])
+
+    s3 = patched_make_client()
+    s3.create_bucket(Bucket=BUCKET)
+    for k in ["cold/1", "cold/2", "cold/3", "warm/1", "hot/1"]:
+        s3.put_object(Bucket=BUCKET, Key=k, Body=b"data")
+
+    # Stage 1
+    dco.main(["identify", "--inventory", "inventory.csv", "--threshold-days", "90"])
+    state = json.load(open(dco.STATE_FILE))
+    check("identify: only cold live objects",
+          sorted(state["candidates"]) == ["cold/1", "cold/2", "cold/3", "warm/1"],
+          str(sorted(state["candidates"])))
+
+    # Stage 2
+    s3.put_object_tagging(Bucket=BUCKET, Key="cold/1",
+                          Tagging={"TagSet": [{"Key": "team", "Value": "ml"}]})
+    dco.main(["quarantine"])
+    tags = {t["Key"]: t["Value"]
+            for t in s3.get_object_tagging(Bucket=BUCKET, Key="cold/1")["TagSet"]}
+    check("quarantine: tag applied", tags.get("quarantine_set") is not None, str(tags))
+    check("quarantine: pre-existing tag preserved", tags.get("team") == "ml", str(tags))
+    # backdate quarantine_date to 30 days ago so the buffer window has elapsed
+    state = json.load(open(dco.STATE_FILE))
+    state["quarantine_date"] = (now - timedelta(days=30)).strftime("%Y-%m-%d")
+    json.dump(state, open(dco.STATE_FILE, "w"))
+
+    # Stage 3: fresh inventory — warm/1 accessed during window is spared
+    write_inv("inventory_fresh.csv", [
+        row("cold/1", old), row("cold/2", old), row("cold/3", old),
+        row("warm/1", accessed_during),
+    ])
+    dco.main(["delete", "--inventory", "inventory_fresh.csv"])
+    confirmed = json.load(open(dco.CONFIRMED_FILE))
+    check("delete: spares object accessed during window",
+          sorted(confirmed) == ["cold/1", "cold/2", "cold/3"], str(sorted(confirmed)))
+    check("delete: versioning enabled",
+          s3.get_bucket_versioning(Bucket=BUCKET).get("Status") == "Enabled")
+    gone = False
+    try:
+        s3.get_object(Bucket=BUCKET, Key="cold/1")
+    except Exception:
+        gone = True
+    check("delete: object soft-deleted", gone)
+    check("delete: warm/1 still live",
+          _readable(s3, "warm/1"))
+
+    # Stage 4 recover: restore cold/2
+    dco.main(["recover", "cold/2"])
+    check("recover: object restored", _readable(s3, "cold/2"))
+    confirmed = json.load(open(dco.CONFIRMED_FILE))
+    check("recover: key dropped from cleanup list",
+          sorted(confirmed) == ["cold/1", "cold/3"], str(sorted(confirmed)))
+
+    # Stage 4 cleanup
+    dco.main(["cleanup"])
+    lov = s3.list_object_versions(Bucket=BUCKET, Prefix="cold/1")
+    remaining = len(lov.get("Versions", [])) + len(lov.get("DeleteMarkers", []))
+    check("cleanup: purged key fully removed", remaining == 0, f"remaining={remaining}")
+    check("cleanup: restored cold/2 survives", _readable(s3, "cold/2"))
+    check("cleanup: unrelated hot/1 survives", _readable(s3, "hot/1"))
+
+
+def _readable(s3, key):
+    try:
+        s3.get_object(Bucket=BUCKET, Key=key)
+        return True
+    except Exception:
+        return False
+
+
+if __name__ == "__main__":
+    run()
+    passed = sum(1 for _, c, _ in results if c)
+    print(f"\n{passed}/{len(results)} checks passed")
+    for name, cond, detail in results:
+        if not cond:
+            print(f"  FAILED: {name} — {detail}")
+    raise SystemExit(0 if passed == len(results) else 1)


### PR DESCRIPTION
## Summary

Adds `storage/delete-cold-objects/`, the supporting script for the **Delete cold objects** guide ([DOCS-2662](https://coreweave.atlassian.net/browse/DOCS-2662), docs PR coreweave/docs#3101).

`delete_cold_objects.py` is a single-file, staged workflow for safely identifying and deleting cold objects in CoreWeave AI Object Storage when the source of truth lives elsewhere. It exposes each stage as a subcommand:

- `identify` (Stage 1) — list cold candidates from an inventory report.
- `quarantine` (Stage 2) — tag candidates and persist state for the buffer window.
- `delete` (Stage 3) — re-check access times, enable versioning, delete confirmed keys.
- `recover` (Stage 4) — restore mistakenly deleted keys before cleanup.
- `cleanup` (Stage 4) — permanently remove recovery copies and delete markers.

Configuration is via `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `BUCKET` (plus optional `ENDPOINT_URL`, `REGION`).

## Contents

- `storage/delete-cold-objects/delete_cold_objects.py` — the workflow.
- `storage/delete-cold-objects/README.md` — usage and configuration.
- `storage/delete-cold-objects/test_delete_cold_objects.py` — end-to-end test.

## Test plan

- [x] End-to-end test passes (12/12) against a mock S3 backend (`moto`): identify → quarantine → delete → recover → cleanup, verifying re-check spares objects accessed during the buffer window, deletes are recoverable, cleanup is key-scoped, and unrelated objects are untouched.
- [x] `python -m py_compile` and `--help` succeed.
- [ ] Validation against a real AI Object Storage bucket (confirms the exact tag-limit error string, the inventory `fileSchema` column order, and lifecycle `ExpiredObjectDeleteMarker` behavior).

Once this merges, the guide in coreweave/docs#3101 will link this file.

> Draft — do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2662]: https://coreweave.atlassian.net/browse/DOCS-2662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ